### PR TITLE
CT-629 - Handle timeout error

### DIFF
--- a/lib/inkind/exception/connection_exception.rb
+++ b/lib/inkind/exception/connection_exception.rb
@@ -1,5 +1,14 @@
 module Inkind
   module Exception
-    class ConnectionException < StandardError; end
+    class ConnectionException < RuntimeError
+
+      attr_reader :raw_response
+
+      def initialize(raw_response = nil)
+        @raw_response = raw_response
+      end
+    end
+
+    class TimeoutException < ConnectionException; end
   end
 end

--- a/lib/inkind/request/base.rb
+++ b/lib/inkind/request/base.rb
@@ -1,28 +1,47 @@
 module Inkind
   module Request
     class Base
+
+      OPEN_TIMEOUT = 5
+      READ_TIMEOUT = 30
+
       def initialize(config:)
         @config ||= config
+        @conn   = Faraday.new(url: config.base_url) do |c|
+          c.adapter :net_http do |http|
+            http.open_timeout = OPEN_TIMEOUT
+            http.read_timeout = READ_TIMEOUT
+          end
+        end
       end
 
       protected
 
-      attr_accessor :config
+      attr_accessor :config, :conn
 
       def get(url, parameters = {})
-        conn = Faraday.new(url: config.base_url)
-        # IMPROVE: Should catch a ConnectionError if failing
-        response = conn.get(url, parameters, get_headers)
-        json     = JSON.parse(response.body)
+        begin
+          response = conn.get(url, parameters, get_headers)
+        rescue Faraday::TimeoutError => e # Used for read_timeout
+          raise Inkind::Exception::TimeoutException.new(e.message)
+        rescue => e # Used for open_timeout (Faraday::ConnectionFailed), and friends
+          raise Inkind::Exception::ConnectionException.new(e.message)
+        end
+
+        json = JSON.parse(response.body)
         capture_error json
         yield json
       end
 
       def post(url, parameters)
-        conn = Faraday.new(url: config.base_url)
-        # IMPROVE: Should catch a ConnectionError if failing
-        response = conn.post(url, parameters, post_headers)
-        json     = JSON.parse(response.body)
+        begin
+          response = conn.post(url, parameters, post_headers)
+        rescue Faraday::TimeoutError => e # Used for read_timeout
+          raise Inkind::Exception::TimeoutException.new(e.message)
+        rescue => e # Used for open_timeout (Faraday::ConnectionFailed), and friends
+          raise Inkind::Exception::ConnectionException.new(e.message)
+        end
+        json = JSON.parse(response.body)
         capture_error json
         yield json
       end
@@ -38,8 +57,8 @@ module Inkind
       def authentication_headers
         nonce = (Time.now.to_f * 1000).to_s
         {
-          'X-TransferTo-Nonce' => nonce,
-          'X-TransferTo-Hmac' => calculate_hmac(nonce),
+          'X-TransferTo-Nonce'  => nonce,
+          'X-TransferTo-Hmac'   => calculate_hmac(nonce),
           'X-TransferTo-Apikey' => config.api_key
         }
       end

--- a/lib/inkind/version.rb
+++ b/lib/inkind/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Inkind
-  VERSION = '0.1.0'.freeze
+  VERSION = '0.1.1'.freeze
 end

--- a/spec/inkind/factory/request_spec.rb
+++ b/spec/inkind/factory/request_spec.rb
@@ -4,19 +4,19 @@ describe Inkind::Factory::Request do
 
     context 'with valid type' do
       it 'returns a Discovery request with :discovery' do
-        request = described_class.create(:discovery, config: config)
+        request = described_class.create(:discovery, config)
         expect(request).to be_a Inkind::Request::Discovery
       end
 
       it 'returns a Transaction request with :transaction' do
-        request = described_class.create(:transaction, config: config)
+        request = described_class.create(:transaction, config)
         expect(request).to be_a Inkind::Request::Transaction
       end
     end
 
     context 'with invalid type' do
       it 'raises an error with :foo' do
-        expect { described_class.create(:foo, config: config) }.to raise_error StandardError
+        expect { described_class.create(:foo, config) }.to raise_error StandardError
       end
     end
   end

--- a/spec/inkind/request/discovery_spec.rb
+++ b/spec/inkind/request/discovery_spec.rb
@@ -7,6 +7,24 @@ describe Inkind::Request::Discovery do
         expect(subject.ping?).to be(true)
       end
     end
+
+    context 'when receiving a Faraday::TimeoutError' do
+      before do
+        allow_any_instance_of(Faraday::Connection).to receive(:get).and_raise(Faraday::TimeoutError.new)
+      end
+      it 'raises a Inkind::Exception::TimeoutException error' do
+        expect{subject.ping?}.to raise_exception Inkind::Exception::TimeoutException
+      end
+    end
+
+    context 'when receiving a Faraday::ConnectionFailed' do
+      before do
+        allow_any_instance_of(Faraday::Connection).to receive(:get).and_raise(Faraday::ConnectionFailed.new('connection failed'))
+      end
+      it 'raises a Inkind::Exception::TimeoutException error' do
+        expect{subject.ping?}.to raise_exception Inkind::Exception::ConnectionException
+      end
+    end
   end
 
   describe '#countries' do

--- a/spec/inkind/request/transaction_spec.rb
+++ b/spec/inkind/request/transaction_spec.rb
@@ -2,18 +2,34 @@ describe Inkind::Request::Transaction do
   subject { described_class.new(config: Inkind::Config.new) }
 
   describe '#fixed_value_voucher' do
-    context 'with valid data' do
-      let(:valid_parameters) { { 'account_number' => '6281234567890', 'product_id' => '112', 'external_id' => '14248512386098429', 'simulation' => '1', 'sender_sms_notification' => '1', 'sender_sms_text' => 'Sender message', 'recipient_sms_notification' => '1', 'recipient_sms_text' => 'Recipient message', 'sender' => { 'last_name' => 'Delorm', 'middle_name' => '', 'first_name' => 'John', 'email' => 'john@testaccount.com', 'mobile' => '6012345678' }, 'recipient' => { 'last_name' => 'Delorm', 'middle_name' => '', 'first_name' => 'Lisa', 'email' => 'lisa@testaccount.com', 'mobile' => '6281234567890' } } }
+    let(:valid_parameters) { { 'account_number' => '6281234567890', 'product_id' => '112', 'external_id' => '14248512386098429', 'simulation' => '1', 'sender_sms_notification' => '1', 'sender_sms_text' => 'Sender message', 'recipient_sms_notification' => '1', 'recipient_sms_text' => 'Recipient message', 'sender' => { 'last_name' => 'Delorm', 'middle_name' => '', 'first_name' => 'John', 'email' => 'john@testaccount.com', 'mobile' => '6012345678' }, 'recipient' => { 'last_name' => 'Delorm', 'middle_name' => '', 'first_name' => 'Lisa', 'email' => 'lisa@testaccount.com', 'mobile' => '6281234567890' } } }
 
-      it 'returns a FixedValueVoucher response' do
-        expect(Inkind::Entity::Response::FixedValueVoucher)
-          .to receive(:new)
-                .at_least(:once)
-                .and_call_original
+    it 'returns a FixedValueVoucher response' do
+      expect(Inkind::Entity::Response::FixedValueVoucher)
+        .to receive(:new)
+              .at_least(:once)
+              .and_call_original
 
-        VCR.use_cassette('fixed_value_vouchers') do
-          expect(subject.fixed_value_voucher(attributes: valid_parameters)).to be_a Inkind::Entity::Response::FixedValueVoucher
-        end
+      VCR.use_cassette('fixed_value_vouchers') do
+        expect(subject.fixed_value_voucher(attributes: valid_parameters)).to be_a Inkind::Entity::Response::FixedValueVoucher
+      end
+    end
+
+    context 'when receiving a Faraday::TimeoutError' do
+      before do
+        allow_any_instance_of(Faraday::Connection).to receive(:post).and_raise(Faraday::TimeoutError.new)
+      end
+      it 'raises a Inkind::Exception::TimeoutException error' do
+        expect{expect(subject.fixed_value_voucher(attributes: valid_parameters)).to be_a Inkind::Entity::Response::FixedValueVoucher}.to raise_exception Inkind::Exception::TimeoutException
+      end
+    end
+
+    context 'when receiving a Faraday::ConnectionFailed' do
+      before do
+        allow_any_instance_of(Faraday::Connection).to receive(:post).and_raise(Faraday::ConnectionFailed.new('connection failed'))
+      end
+      it 'raises a Inkind::Exception::TimeoutException error' do
+        expect{expect(subject.fixed_value_voucher(attributes: valid_parameters)).to be_a Inkind::Entity::Response::FixedValueVoucher}.to raise_exception Inkind::Exception::ConnectionException
       end
     end
   end
@@ -33,7 +49,6 @@ describe Inkind::Request::Transaction do
         allow_any_instance_of(Faraday::Connection).to receive(:get).and_return(fixed_value_vouchers_api_response)
         expect(subject.status(:fixed_value_vouchers, 1234567890)).to be_a Inkind::Entity::Response::FixedValueVoucher
       end
-
     end
   end
 


### PR DESCRIPTION
The open timeout is set to 5s.
The read timeout is set to 30s.

When a call is made to the distant API, if a Faraday::TimeoutError (read_timeout) or any other error (eg: Faraday::ConnectionFailed, ...), those errors will be caught and Inkind errors will be raised instead. Respectively Inkind::Exception::TimeoutException and Inkind::Exception::ConnectionException.